### PR TITLE
[Feat] 임대주택 공고 목록 페이징 처리 및 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/bango/domain/noticelike/repository/NoticeLikeRepository.java
+++ b/src/main/java/com/ssafy/bango/domain/noticelike/repository/NoticeLikeRepository.java
@@ -21,4 +21,6 @@ public interface NoticeLikeRepository extends JpaRepository<NoticeLike, Integer>
 
     @Query("SELECT nl.rentalNotice.noticeId FROM NoticeLike nl WHERE nl.member.memberId = :memberId")
     List<Integer> findLikedNoticeIdsByMemberId(@Param("memberId") Long memberId);
+
+    boolean existsByMember_MemberIdAndRentalNotice_NoticeId(long memberId, int noticeId);
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
@@ -1,12 +1,14 @@
 package com.ssafy.bango.domain.rentalnotice.controller;
 
 import com.ssafy.bango.domain.rentalnotice.dto.NoticeListResponseWithLiked;
+import com.ssafy.bango.domain.rentalnotice.dto.NoticeWithLiked;
 import com.ssafy.bango.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
 import java.security.Principal;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "임대 주택 공고 컨트롤러", description = "임대 주택 공고 관련 API입니다.")
 public interface RentalNoticeApi {
@@ -19,4 +21,9 @@ public interface RentalNoticeApi {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 목록 조회 완료")
     })
     ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> getRentalListWithLike(int pageNo, int pageSize, Principal principal);
+
+    @Operation(summary = "공고 상세 조회", description = "로그인 되지 않은 경우(/) 공고 상세 조회하는 API 입니다.", responses = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상세 조회 완료")
+    })
+    ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalWithLike(@PathVariable int noticeId, Principal principal);
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
@@ -17,12 +17,12 @@ public interface RentalNoticeApi {
     })
     void getRentalListTest();
 
-    @Operation(summary = "공고 조회", description = "로그인 되지 않은 경우(/) 공고 목록을 조회하는 API 입니다.", responses = {
+    @Operation(summary = "공고 조회", description = "로그인 되지 않은 경우(/), 로그인 된 경우(/like) 공고 목록을 조회하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 목록 조회 완료")
     })
     ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> getRentalListWithLike(int pageNo, int pageSize, Principal principal);
 
-    @Operation(summary = "공고 상세 조회", description = "로그인 되지 않은 경우(/) 공고 상세 조회하는 API 입니다.", responses = {
+    @Operation(summary = "공고 상세 조회", description = "로그인 되지 않은 경우(/), 로그인 된 경우(/like) 공고 상세 조회하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상세 조회 완료")
     })
     ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalWithLike(@PathVariable int noticeId, Principal principal);

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
@@ -1,11 +1,13 @@
 package com.ssafy.bango.domain.rentalnotice.controller;
 
 import com.ssafy.bango.domain.rentalnotice.dto.NoticeListResponseWithLiked;
+import com.ssafy.bango.domain.rentalnotice.dto.NoticeWithLiked;
 import com.ssafy.bango.domain.rentalnotice.service.RentalNoticeService;
 import com.ssafy.bango.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.security.Principal;
 
 import static com.ssafy.bango.global.exception.enums.SuccessType.GET_RENTALNOTICE_LIST_SUCCESS;
+import static com.ssafy.bango.global.exception.enums.SuccessType.GET_RENTALNOTICE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,6 +42,18 @@ public class RentalNoticeController implements RentalNoticeApi {
         return ResponseEntity.ok(ApiResponse.success(
                 GET_RENTALNOTICE_LIST_SUCCESS,
                 rentalNoticeService.getNoticeListWithLiked(pageNo, pageSize, principal)
+        ));
+    }
+
+    /**
+     * 로그인된 경우 "/like"
+     * 로그인 되지 않은 경우 ""
+     */
+    @GetMapping(value = {"/{noticeId}", "/like/{noticeId}"})
+    public ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalWithLike(@PathVariable int noticeId, Principal principal) {
+        return ResponseEntity.ok(ApiResponse.success(
+            GET_RENTALNOTICE_SUCCESS,
+            rentalNoticeService.getNoticeWithLiked(noticeId, principal)
         ));
     }
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/dto/NoticeListResponseWithLiked.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/dto/NoticeListResponseWithLiked.java
@@ -2,9 +2,9 @@ package com.ssafy.bango.domain.rentalnotice.dto;
 
 import java.util.List;
 
-public record NoticeListResponseWithLiked(int pageNo, int pageCount, List<NoticeWithLiked> noticeWithLikeds) {
+public record NoticeListResponseWithLiked(int totalPageNo, long totalPageCount, int pageNo, int pageCount, List<NoticeWithLiked> noticeWithLikeds) {
 
-    public static NoticeListResponseWithLiked of(int pageNo, int pageCount, List<NoticeWithLiked> noticeWithLikeds) {
-        return new NoticeListResponseWithLiked(pageNo, pageCount, noticeWithLikeds);
+    public static NoticeListResponseWithLiked of(int totalPageNo, long totalPageCount, int pageNo, int pageCount, List<NoticeWithLiked> noticeWithLikeds) {
+        return new NoticeListResponseWithLiked(totalPageNo, totalPageCount, pageNo, pageCount, noticeWithLikeds);
     }
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
@@ -51,8 +51,9 @@ public class RentalNoticeService {
                 .map(notice -> NoticeWithLiked.of(notice, noticeLikeSet.contains(notice.getNoticeId())))
                 .toList();
 
-
         return NoticeListResponseWithLiked.of(
+                noticeList.getTotalPages(),
+                noticeList.getTotalElements(),
                 pageNo,
                 noticeList.getNumberOfElements(),
                 result

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
@@ -7,6 +7,8 @@ import com.ssafy.bango.domain.rentalnotice.entity.RentalNotice;
 import com.ssafy.bango.domain.rentalnotice.feign.RentalNoticeApiService;
 import com.ssafy.bango.domain.rentalnotice.repository.RentalNoticeRepository;
 import com.ssafy.bango.global.auth.jwt.JwtProvider;
+import com.ssafy.bango.global.exception.CustomException;
+import com.ssafy.bango.global.exception.enums.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -58,6 +60,22 @@ public class RentalNoticeService {
                 noticeList.getNumberOfElements(),
                 result
         );
+    }
+
+    public NoticeWithLiked getNoticeWithLiked(int noticeId, Principal principal) {
+        RentalNotice notice = getRentalNotice(noticeId);
+
+        boolean isLiked = false;
+        if (!isNull(principal)) {
+            long memberId = JwtProvider.getMemberIdFromPrincipal(principal);
+            isLiked = noticeLikeRepository.existsByMember_MemberIdAndRentalNotice_NoticeId(memberId, noticeId);
+        }
+        return NoticeWithLiked.of(notice, isLiked);
+    }
+
+    private RentalNotice getRentalNotice(int noticeId) {
+        return rentalNoticeRepository.findById(noticeId)
+        .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_NOTICE_ERROR));
     }
 
     /**


### PR DESCRIPTION
## 🔥Pull requests
👷 작업한 내용
- 공고 pagination에 필요한 변수 추가 및 수정
- 공고 상세 조회 API 구현
- Swagger 설명 변경 등 스타일 수정
- 로그인 여부에 따라 공고 목록 및 상세 조회에 좋아요 기능 포함

🚨 참고 사항

📸 스크린샷

|기능|스크린샷|
|--|--|
|임대주택 상세정보 조회|<img width="1476" alt="image" src="https://github.com/user-attachments/assets/4b14249e-43c2-4683-8611-77aa0e0feef2" />|

📟 관련 이슈
- Resolved: #39 
