### PR TITLE
[FEAT] 공고 필터링 검색 API 구현

### DIFF
--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
@@ -27,7 +27,7 @@ public interface RentalNoticeApi {
     })
     ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> searchRentalNotices(int pageNo, int pageSize, String status, String supplyType, Principal principal);
 
-    @Operation(summary = "공고 상세 조회", description = "로그인 되지 않은 경우(/), 로그인 된 경우(/like) 공고 상세 조회하는 API 입니다.", responses = {
+    @Operation(summary = "공고 상세 조회", description = "공고 상세 조회하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상세 조회 완료")
     })
     ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalWithLike(@PathVariable int noticeId, Principal principal);

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
@@ -22,6 +22,11 @@ public interface RentalNoticeApi {
     })
     ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> getRentalListWithLike(int pageNo, int pageSize, Principal principal);
 
+    @Operation(summary = "공고 검색 조회", description = "공고 목록을 검색하는 API 입니다.", responses = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 목록 검색 완료")
+    })
+    ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> searchRentalNotices(int pageNo, int pageSize, String status, String supplyType, Principal principal);
+
     @Operation(summary = "공고 상세 조회", description = "로그인 되지 않은 경우(/), 로그인 된 경우(/like) 공고 상세 조회하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상세 조회 완료")
     })

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeApi.java
@@ -15,12 +15,12 @@ public interface RentalNoticeApi {
     @Operation(summary = "dummy 임대 주택 공고 쌓기", description = "dummy 임대 주택 공고 데이터를 DB에 적재하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "dummy 임대 주택 공고 쌓기 완료")
     })
-    void getRentalListTest();
+    void loadDummyRentalNotices();
 
     @Operation(summary = "공고 조회", description = "로그인 되지 않은 경우(/), 로그인 된 경우(/like) 공고 목록을 조회하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 목록 조회 완료")
     })
-    ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> getRentalListWithLike(int pageNo, int pageSize, Principal principal);
+    ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> getRentalNoticesWithLike(int pageNo, int pageSize, Principal principal);
 
     @Operation(summary = "공고 검색 조회", description = "공고 목록을 검색하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 목록 검색 완료")
@@ -30,5 +30,5 @@ public interface RentalNoticeApi {
     @Operation(summary = "공고 상세 조회", description = "공고 상세 조회하는 API 입니다.", responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상세 조회 완료")
     })
-    ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalWithLike(@PathVariable int noticeId, Principal principal);
+    ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalNoticeWithLike(@PathVariable int noticeId, Principal principal);
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
@@ -39,10 +39,7 @@ public class RentalNoticeController implements RentalNoticeApi {
             @RequestParam(defaultValue = "10") int pageSize,
             Principal principal
     ) {
-        return ResponseEntity.ok(ApiResponse.success(
-                GET_RENTALNOTICE_LIST_SUCCESS,
-                rentalNoticeService.getNoticeListWithLiked(pageNo, pageSize, principal)
-        ));
+        return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_LIST_SUCCESS, rentalNoticeService.getNoticeListWithLiked(pageNo, pageSize, principal)));
     }
 
     @GetMapping("/search")
@@ -57,15 +54,8 @@ public class RentalNoticeController implements RentalNoticeApi {
         return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_LIST_SUCCESS, response));
     }
 
-    /**
-     * 로그인된 경우 "/like"
-     * 로그인 되지 않은 경우 ""
-     */
-    @GetMapping(value = {"/{noticeId}", "/like/{noticeId}"})
+    @GetMapping("/{noticeId}")
     public ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalWithLike(@PathVariable int noticeId, Principal principal) {
-        return ResponseEntity.ok(ApiResponse.success(
-            GET_RENTALNOTICE_SUCCESS,
-            rentalNoticeService.getNoticeWithLiked(noticeId, principal)
-        ));
+        return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_SUCCESS, rentalNoticeService.getNoticeWithLiked(noticeId, principal)));
     }
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
@@ -45,6 +45,18 @@ public class RentalNoticeController implements RentalNoticeApi {
         ));
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> searchRentalNotices(
+        @RequestParam(defaultValue = "1") int pageNo,
+        @RequestParam(defaultValue = "10") int pageSize,
+        @RequestParam(required = false) String status,
+        @RequestParam(required = false) String supplyType,
+        Principal principal
+    ) {
+        NoticeListResponseWithLiked response = rentalNoticeService.searchNoticeListWithLiked(pageNo, pageSize, status, supplyType, principal);
+        return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_LIST_SUCCESS, response));
+    }
+
     /**
      * 로그인된 경우 "/like"
      * 로그인 되지 않은 경우 ""

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
@@ -24,17 +24,16 @@ public class RentalNoticeController implements RentalNoticeApi {
     private final RentalNoticeService rentalNoticeService;
 
     @GetMapping("/dump")
-    public void getRentalListTest() {
+    public void loadDummyRentalNotices() {
         rentalNoticeService.dumpRentalNoticeTable();
     }
-
 
     /**
      * 로그인된 경우 "/like"
      * 로그인 되지 않은 경우 ""
      */
     @GetMapping(value = {"", "/like"})
-    public ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> getRentalListWithLike(
+    public ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> getRentalNoticesWithLike(
             @RequestParam(defaultValue = "1") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize,
             Principal principal
@@ -55,7 +54,7 @@ public class RentalNoticeController implements RentalNoticeApi {
     }
 
     @GetMapping("/{noticeId}")
-    public ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalWithLike(@PathVariable int noticeId, Principal principal) {
+    public ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalNoticeWithLike(@PathVariable int noticeId, Principal principal) {
         return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_SUCCESS, rentalNoticeService.getNoticeWithLiked(noticeId, principal)));
     }
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/repository/RentalNoticeRepository.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/repository/RentalNoticeRepository.java
@@ -4,9 +4,9 @@ import com.ssafy.bango.domain.rentalnotice.entity.RentalNotice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RentalNoticeRepository extends JpaRepository<RentalNotice, Integer> {
-    Page<RentalNotice> findAll(Pageable pageable);
+public interface RentalNoticeRepository extends JpaRepository<RentalNotice, Integer>, JpaSpecificationExecutor<RentalNotice> {
 }

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
@@ -32,37 +32,53 @@ import static java.util.Objects.isNull;
 public class RentalNoticeService {
     private final RentalNoticeRepository rentalNoticeRepository;
     private final NoticeLikeRepository noticeLikeRepository;
-
     private final RentalNoticeApiService rentalNoticeApiService;
-
 
     public NoticeListResponseWithLiked getNoticeListWithLiked(int pageNo, int pageSize, Principal principal) {
         Pageable pageable = PageRequest.of(pageNo - 1, pageSize);
-
-        // 와 이거 너무 맘에 안들어요
-
-
-        long memberId;
-        Set<Integer> noticeLikeSet;
-        if (!isNull(principal)) {
-            memberId = JwtProvider.getMemberIdFromPrincipal(principal);
-            noticeLikeSet = new HashSet<>(noticeLikeRepository.findLikedNoticeIdsByMemberId(memberId));
-        } else noticeLikeSet = new HashSet<>();
-
-
         Page<RentalNotice> noticeList = rentalNoticeRepository.findAll(pageable);
+        return convertToResponseWithLiked(noticeList, principal, pageNo);
+    }
 
-        List<NoticeWithLiked> result = noticeList.stream()
-                .map(notice -> NoticeWithLiked.of(notice, noticeLikeSet.contains(notice.getNoticeId())))
-                .toList();
+    public NoticeListResponseWithLiked searchNoticeListWithLiked(int pageNo, int pageSize, String status, String supplyType, Principal principal) {
+        Specification<RentalNotice> spec = buildSpecification(status, supplyType);
+        Pageable pageable = PageRequest.of(pageNo - 1, pageSize);
+        Page<RentalNotice> filteredList = rentalNoticeRepository.findAll(spec, pageable);
+        return convertToResponseWithLiked(filteredList, principal, pageNo);
+    }
+
+    private NoticeListResponseWithLiked convertToResponseWithLiked(Page<RentalNotice> page, Principal principal, int pageNo) {
+        Set<Integer> likedIds = getLikedNoticeIds(principal);
+
+        List<NoticeWithLiked> notices = page.stream()
+            .map(notice -> NoticeWithLiked.of(notice, likedIds.contains(notice.getNoticeId())))
+            .toList();
 
         return NoticeListResponseWithLiked.of(
-                noticeList.getTotalPages(),
-                noticeList.getTotalElements(),
-                pageNo,
-                noticeList.getNumberOfElements(),
-                result
+            page.getTotalPages(),
+            page.getTotalElements(),
+            pageNo,
+            page.getNumberOfElements(),
+            notices
         );
+    }
+
+    private Set<Integer> getLikedNoticeIds(Principal principal) {
+        if (principal == null) return Set.of();
+        long memberId = JwtProvider.getMemberIdFromPrincipal(principal);
+        return new HashSet<>(noticeLikeRepository.findLikedNoticeIdsByMemberId(memberId));
+    }
+
+    private Specification<RentalNotice> buildSpecification(String status, String supplyType) {
+        Specification<RentalNotice> spec = Specification.where(null);
+
+        if (StringUtils.hasText(status)) {
+            spec = spec.and(RentalNoticeSpecifications.byStatusPeriod(status));
+        }
+        if (StringUtils.hasText(supplyType)) {
+            spec = spec.and(RentalNoticeSpecifications.bySupplyType(supplyType));
+        }
+        return spec;
     }
 
     public NoticeWithLiked getNoticeWithLiked(int noticeId, Principal principal) {
@@ -79,46 +95,6 @@ public class RentalNoticeService {
     private RentalNotice getRentalNotice(int noticeId) {
         return rentalNoticeRepository.findById(noticeId)
         .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_NOTICE_ERROR));
-    }
-
-    public NoticeListResponseWithLiked searchNoticeListWithLiked(
-        int pageNo, int pageSize, String status, String supplyType, Principal principal) {
-
-        Specification<RentalNotice> spec = buildSpecification(status, supplyType);
-        Pageable pageable = PageRequest.of(pageNo - 1, pageSize);
-        Page<RentalNotice> page = rentalNoticeRepository.findAll(spec, pageable);
-
-        Set<Integer> likedIds = getLikedNoticeIds(principal);
-        List<NoticeWithLiked> notices = page.stream()
-            .map(notice -> NoticeWithLiked.of(notice, likedIds.contains(notice.getNoticeId())))
-            .toList();
-
-        return NoticeListResponseWithLiked.of(
-            page.getTotalPages(),
-            page.getTotalElements(),
-            pageNo,
-            page.getNumberOfElements(),
-            notices
-        );
-    }
-
-    private Specification<RentalNotice> buildSpecification(String status, String supplyType) {
-        Specification<RentalNotice> spec = Specification.where(null);
-
-        if (StringUtils.hasText(status)) {
-            spec = spec.and(RentalNoticeSpecifications.byStatusPeriod(status));
-        }
-        if (StringUtils.hasText(supplyType)) {
-            spec = spec.and(RentalNoticeSpecifications.bySupplyType(supplyType));
-        }
-        return spec;
-    }
-
-    private Set<Integer> getLikedNoticeIds(Principal principal) {
-        if (principal == null) return Set.of();
-
-        long memberId = JwtProvider.getMemberIdFromPrincipal(principal);
-        return new HashSet<>(noticeLikeRepository.findLikedNoticeIdsByMemberId(memberId));
     }
 
     /**

--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/service/RentalNoticeService.java
@@ -9,10 +9,12 @@ import com.ssafy.bango.domain.rentalnotice.repository.RentalNoticeRepository;
 import com.ssafy.bango.global.auth.jwt.JwtProvider;
 import com.ssafy.bango.global.exception.CustomException;
 import com.ssafy.bango.global.exception.enums.ErrorType;
+import com.ssafy.bango.global.util.RentalNoticeSpecifications;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ import java.security.Principal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.springframework.util.StringUtils;
 
 import static java.util.Objects.isNull;
 
@@ -76,6 +79,46 @@ public class RentalNoticeService {
     private RentalNotice getRentalNotice(int noticeId) {
         return rentalNoticeRepository.findById(noticeId)
         .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_NOTICE_ERROR));
+    }
+
+    public NoticeListResponseWithLiked searchNoticeListWithLiked(
+        int pageNo, int pageSize, String status, String supplyType, Principal principal) {
+
+        Specification<RentalNotice> spec = buildSpecification(status, supplyType);
+        Pageable pageable = PageRequest.of(pageNo - 1, pageSize);
+        Page<RentalNotice> page = rentalNoticeRepository.findAll(spec, pageable);
+
+        Set<Integer> likedIds = getLikedNoticeIds(principal);
+        List<NoticeWithLiked> notices = page.stream()
+            .map(notice -> NoticeWithLiked.of(notice, likedIds.contains(notice.getNoticeId())))
+            .toList();
+
+        return NoticeListResponseWithLiked.of(
+            page.getTotalPages(),
+            page.getTotalElements(),
+            pageNo,
+            page.getNumberOfElements(),
+            notices
+        );
+    }
+
+    private Specification<RentalNotice> buildSpecification(String status, String supplyType) {
+        Specification<RentalNotice> spec = Specification.where(null);
+
+        if (StringUtils.hasText(status)) {
+            spec = spec.and(RentalNoticeSpecifications.byStatusPeriod(status));
+        }
+        if (StringUtils.hasText(supplyType)) {
+            spec = spec.and(RentalNoticeSpecifications.bySupplyType(supplyType));
+        }
+        return spec;
+    }
+
+    private Set<Integer> getLikedNoticeIds(Principal principal) {
+        if (principal == null) return Set.of();
+
+        long memberId = JwtProvider.getMemberIdFromPrincipal(principal);
+        return new HashSet<>(noticeLikeRepository.findLikedNoticeIdsByMemberId(memberId));
     }
 
     /**

--- a/src/main/java/com/ssafy/bango/global/util/RentalNoticeSpecifications.java
+++ b/src/main/java/com/ssafy/bango/global/util/RentalNoticeSpecifications.java
@@ -5,17 +5,22 @@ import java.time.LocalDate;
 import org.springframework.data.jpa.domain.Specification;
 
 public class RentalNoticeSpecifications {
+    public static final String STATUS_RECRUITING = "모집중";
+    public static final String STATUS_UPCOMING = "모집예정";
+    public static final String STATUS_COMPLETED = "모집완료";
+
     public static Specification<RentalNotice> byStatusPeriod(String status) {
         return (root, query, cb) -> {
-            LocalDate today = LocalDate.now();
+            if (status == null || status.trim().isEmpty()) return null; // 필터링 안 함
 
-            return switch (status.toLowerCase()) {
-                case "모집중" -> cb.and(
+            LocalDate today = LocalDate.now();
+            return switch (status.trim()) {
+                case STATUS_RECRUITING -> cb.and(
                     cb.lessThanOrEqualTo(root.get("beginDate"), today),
                     cb.greaterThanOrEqualTo(root.get("endDate"), today)
                 );
-                case "모집예정" -> cb.greaterThan(root.get("beginDate"), today);
-                case "모집완료" -> cb.lessThan(root.get("endDate"), today);
+                case STATUS_UPCOMING -> cb.greaterThan(root.get("beginDate"), today);
+                case STATUS_COMPLETED -> cb.lessThan(root.get("endDate"), today);
                 default -> null; // 필터링 안 함
             };
         };

--- a/src/main/java/com/ssafy/bango/global/util/RentalNoticeSpecifications.java
+++ b/src/main/java/com/ssafy/bango/global/util/RentalNoticeSpecifications.java
@@ -27,6 +27,9 @@ public class RentalNoticeSpecifications {
     }
 
     public static Specification<RentalNotice> bySupplyType(String supplyType) {
-        return (root, query, cb) -> cb.equal(root.get("supplyType"), supplyType);
+        return (root, query, cb) -> {
+            if (supplyType == null || supplyType.trim().isEmpty()) return null; // 필터링 안 함
+            return cb.equal(root.get("supplyType"), supplyType.trim());
+        };
     }
 }

--- a/src/main/java/com/ssafy/bango/global/util/RentalNoticeSpecifications.java
+++ b/src/main/java/com/ssafy/bango/global/util/RentalNoticeSpecifications.java
@@ -1,0 +1,27 @@
+package com.ssafy.bango.global.util;
+
+import com.ssafy.bango.domain.rentalnotice.entity.RentalNotice;
+import java.time.LocalDate;
+import org.springframework.data.jpa.domain.Specification;
+
+public class RentalNoticeSpecifications {
+    public static Specification<RentalNotice> byStatusPeriod(String status) {
+        return (root, query, cb) -> {
+            LocalDate today = LocalDate.now();
+
+            return switch (status.toLowerCase()) {
+                case "모집중" -> cb.and(
+                    cb.lessThanOrEqualTo(root.get("beginDate"), today),
+                    cb.greaterThanOrEqualTo(root.get("endDate"), today)
+                );
+                case "모집예정" -> cb.greaterThan(root.get("beginDate"), today);
+                case "모집완료" -> cb.lessThan(root.get("endDate"), today);
+                default -> null; // 필터링 안 함
+            };
+        };
+    }
+
+    public static Specification<RentalNotice> bySupplyType(String supplyType) {
+        return (root, query, cb) -> cb.equal(root.get("supplyType"), supplyType);
+    }
+}


### PR DESCRIPTION
## 🔥Pull requests
👷 작업한 내용
- 공고 필터링 검색 API 구현

🚨 참고 사항

📸 스크린샷
|기능|스크린샷|
|--|--|
|검색 API|<img width="1258" alt="image" src="https://github.com/user-attachments/assets/ec9066e8-77f2-4cc5-8816-5a18e6104a31" />|

📟 관련 이슈
- Resolved: #42 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 임대 공고를 상태 및 공급 유형으로 필터링하여 검색할 수 있는 공고 검색 기능이 추가되었습니다.
  - 검색 결과는 페이지네이션과 함께, 사용자가 좋아요를 누른 공고 여부도 함께 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->