### PR TITLE
[CHORE] 임대주택 공고 api에 prefix 추가

### DIFF
--- a/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
+++ b/src/main/java/com/ssafy/bango/domain/rentalnotice/controller/RentalNoticeController.java
@@ -23,7 +23,7 @@ import static com.ssafy.bango.global.exception.enums.SuccessType.GET_RENTALNOTIC
 public class RentalNoticeController implements RentalNoticeApi {
     private final RentalNoticeService rentalNoticeService;
 
-    @GetMapping("/dump")
+    @GetMapping("/p/dump")
     public void loadDummyRentalNotices() {
         rentalNoticeService.dumpRentalNoticeTable();
     }
@@ -41,7 +41,7 @@ public class RentalNoticeController implements RentalNoticeApi {
         return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_LIST_SUCCESS, rentalNoticeService.getNoticeListWithLiked(pageNo, pageSize, principal)));
     }
 
-    @GetMapping("/search")
+    @GetMapping("/p/search")
     public ResponseEntity<ApiResponse<NoticeListResponseWithLiked>> searchRentalNotices(
         @RequestParam(defaultValue = "1") int pageNo,
         @RequestParam(defaultValue = "10") int pageSize,
@@ -53,7 +53,7 @@ public class RentalNoticeController implements RentalNoticeApi {
         return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_LIST_SUCCESS, response));
     }
 
-    @GetMapping("/{noticeId}")
+    @GetMapping("/p/{noticeId}")
     public ResponseEntity<ApiResponse<NoticeWithLiked>> getRentalNoticeWithLike(@PathVariable int noticeId, Principal principal) {
         return ResponseEntity.ok(ApiResponse.success(GET_RENTALNOTICE_SUCCESS, rentalNoticeService.getNoticeWithLiked(noticeId, principal)));
     }

--- a/src/main/java/com/ssafy/bango/global/auth/security/AuthWhiteList.java
+++ b/src/main/java/com/ssafy/bango/global/auth/security/AuthWhiteList.java
@@ -18,7 +18,7 @@ public class AuthWhiteList {
     public static final List<String> AUTH_WHITELIST_WILDCARD = Arrays.asList(
             "/api/v1/rental/**",
             "/api/v1/rental/api/**",
-            "/api/v1/notice/**",
+            "/api/v1/notice/p/**",
             "/api/v1/dongcode/**",
             "/api/v1/ai/**",
             "/swagger-ui/**",


### PR DESCRIPTION
## 🔥Pull requests
👷 작업한 내용
- 임대주택 공고 api에 prefix 추가

🚨 참고 사항

📸 스크린샷

|기능|스크린샷|
|--|--|
|GIF||

📟 관련 이슈
- Resolved: #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 일부 대여 공지 관련 API 엔드포인트의 URL 경로가 "/p"로 변경되었습니다.
- **Chores**
  - 인증 화이트리스트가 "/api/v1/notice/p/**"로 더 제한적으로 적용되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->